### PR TITLE
allow specification of revision-less versions

### DIFF
--- a/schemas/farm-boolean/v3_1.json
+++ b/schemas/farm-boolean/v3_1.json
@@ -1,0 +1,269 @@
+{
+	"$schema": "http://json-schema.org/draft-06/schema#",
+	"$id": "http://schemas.dev.brightspace.com/feature-flags/farm-boolean/v3_1.json",
+	"type": "object",
+	"additionalProperties": false,
+	"required": [
+		"$schema",
+		"name",
+		"environments"
+	],
+	"properties": {
+		"$schema": {
+			"type": "string",
+			"title": "The schema which uniquely identifies the feature flag type",
+			"enum": [
+				"http://schemas.dev.brightspace.com/feature-flags/farm-boolean/v3_1.json"
+			]
+		},
+		"name": {
+			"type": "string",
+			"title": "The feature flag name",
+			"minLength": 1
+		},
+		"description": {
+			"type": "string",
+			"title": "The description of what the feature flag controls",
+			"minLength": 1
+		},
+		"rallyId": {
+			"type": "string",
+			"title": "The rally identifier for the associated defect/feature.",
+			"pattern": "^(DE|F|US)\\d+"
+		},
+		"variations": {
+			"type": "object",
+			"title": "The keyed enumeration of variations. The keys are referenced elsewhere in the document.",
+			"additionalProperties": false,
+			"required": [
+				"true",
+				"false"
+			],
+			"properties": {
+				"true": {
+					"$ref": "#/definitions/variation",
+					"title": "The true variation key"
+				},
+				"false": {
+					"$ref": "#/definitions/variation",
+					"title": "The false variation key"
+				}
+			}
+		},
+		"environments": {
+			"type": "object",
+			"title": "The environment specific targetting rules",
+			"additionalProperties": false,
+			"required": [
+				"production",
+				"development"
+			],
+			"properties": {
+				"production": {
+					"$ref": "#/definitions/environment",
+					"title": "The production targetting rules"
+				},
+				"development": {
+					"$ref": "#/definitions/environment",
+					"title": "The development targetting rules"
+				}
+			}
+		},
+		"tags": {
+			"title": "The tags associated to the feature flag",
+			"type": "array",
+			"additionalItems": false,
+			"minItems": 1,
+			"uniqueItems": true,
+			"items": {
+				"type": "string",
+				"pattern": "^[a-zA-Z0-9_\\-\\.]+$"
+			}
+		}
+	},
+	"definitions": {
+		"environment": {
+			"type": "object",
+			"additionalProperties": false,
+			"required": [
+				"defaultVariation"
+			],
+			"properties": {
+				"defaultVariation": {
+					"type": "string",
+					"title": "The variation to use when neither targets or rules match",
+					"enum": [
+						"true",
+						"false"
+					]
+				},
+				"targets": {
+					"type": "array",
+					"title": "The explicit farms to target",
+					"additionalItems": false,
+					"minItems": 1,
+					"items": {
+						"$ref": "#/definitions/target"
+					}
+				},
+				"rules": {
+					"type": "array",
+					"title": "The sequential rules which are evaluated when not matched by an explicit target",
+					"additionalItems": false,
+					"minItems": 1,
+					"items": {
+						"$ref": "#/definitions/rule"
+					}
+				},
+				"disabled": {
+					"type": "boolean",
+					"title": "If true, the defaultVariation is always used, and the targets and rules are ignored."
+				}
+			}
+		},
+		"rule": {
+			"type": "object",
+			"title": "A targetting rule",
+			"additionalProperties": false,
+			"required": [
+				"variation"
+			],
+			"minProperties": 2,
+			"properties": {
+				"dataCenters": {
+					"type": "array",
+					"title": "The set of d2l data centers to target",
+					"additionalItems": false,
+					"minItems": 1,
+					"uniqueItems": true,
+					"items": {
+						"type": "string",
+						"title": "Name of a d2l data center",
+						"enum": [
+							"ap01",
+							"ap02",
+							"ca05",
+							"ca1d",
+							"ca1p",
+							"ca3d",
+							"ca3p",
+							"eu01",
+							"us04"
+						]
+					}
+				},
+				"versions": {
+					"type": "object",
+					"title": "The bundle versions to target",
+					"additionalProperties": false,
+					"minProperties": 1,
+					"properties": {
+						"start": {
+							"$ref": "#/definitions/version",
+							"title": "The version to start targetting at (inclusive)",
+							"examples": [
+								"10.8.4.12256"
+							]
+						},
+						"end": {
+							"$ref": "#/definitions/version",
+							"title": "The version to stop targetting at (inclusive)",
+							"examples": [
+								"10.8.4.99999"
+							]
+						}
+					}
+				},
+				"variation": {
+					"type": "string",
+					"title": "The variation to target",
+					"enum": [
+						"true",
+						"false"
+					]
+				}
+			}
+		},
+		"target": {
+			"type": "object",
+			"additionalProperties": false,
+			"required": [
+				"variation"
+			],
+			"minProperties": 2,
+			"properties": {
+				"farms": {
+					"type": "array",
+					"title": "The set of farms to target",
+					"additionalItems": false,
+					"minItems": 1,
+					"uniqueItems": true,
+					"items": {
+						"anyOf": [
+							{
+								"$ref": "#/definitions/farmIdTarget"
+							},
+							{
+								"$ref": "#/definitions/farmTarget"
+							}
+						]
+					}
+				},
+				"variation": {
+					"type": "string",
+					"title": "The variation to target",
+					"enum": [
+						"true",
+						"false"
+					]
+				}
+			}
+		},
+		"farmIdTarget": {
+			"type": "string",
+			"title": "The farm id to target",
+			"pattern": "^[A-Za-z0-9_-]{2,40}$"
+		},
+		"farmTarget": {
+			"type": "object",
+			"additionalProperties": false,
+			"required": [
+				"farmId",
+				"comments"
+			],
+			"properties": {
+				"farmId": {
+					"$ref": "#/definitions/farmIdTarget"
+				},
+				"comments": {
+					"type": "string",
+					"title": "The comments about the farm",
+					"minLength": 1
+				}
+			}
+		},
+		"variation": {
+			"type": "object",
+			"additionalProperties": false,
+			"required": [
+				"name"
+			],
+			"properties": {
+				"name": {
+					"type": "string",
+					"title": "The human readable name of the variation",
+					"minLength": 1
+				},
+				"description": {
+					"type": "string",
+					"title": "The description of what the variation controls",
+					"minLength": 1
+				}
+			}
+		},
+		"version": {
+			"type": "string",
+			"pattern": "^[1-9][0-9]\\.[1-9]?[0-9]\\.[1-9]?[0-9](?:\\.[1-9]?[0-9]{0,4})?$"
+		}
+	}
+}

--- a/schemas/farm-multivariate/v3_2.json
+++ b/schemas/farm-multivariate/v3_2.json
@@ -1,0 +1,269 @@
+{
+	"$schema": "http://json-schema.org/draft-06/schema#",
+	"$id": "http://schemas.dev.brightspace.com/feature-flags/farm-multivariate/v3_2.json",
+	"type": "object",
+	"additionalProperties": false,
+	"required": [
+		"$schema",
+		"name",
+		"environments",
+		"variations"
+	],
+	"properties": {
+		"$schema": {
+			"type": "string",
+			"title": "The schema which uniquely identifies the feature flag type",
+			"enum": [
+				"http://schemas.dev.brightspace.com/feature-flags/farm-multivariate/v3_2.json"
+			]
+		},
+		"name": {
+			"type": "string",
+			"title": "The feature flag name",
+			"minLength": 1
+		},
+		"description": {
+			"type": "string",
+			"title": "The description of what the feature flag controls",
+			"minLength": 1
+		},
+		"rallyId": {
+			"type": "string",
+			"title": "The rally identifier for the associated defect/feature.",
+			"pattern": "^(DE|F|US)\\d+"
+		},
+		"variations": {
+			"type": "array",
+			"title": "The keyed enumeration of variations. The keys are referenced elsewhere in the document.",
+			"additionalItems": false,
+			"minItems": 2,
+			"items": {
+				"$ref": "#/definitions/variation"
+			}
+		},
+		"environments": {
+			"type": "object",
+			"title": "The environment specific targetting rules",
+			"additionalProperties": false,
+			"required": [
+				"production",
+				"development"
+			],
+			"properties": {
+				"production": {
+					"$ref": "#/definitions/environment",
+					"title": "The production targetting rules"
+				},
+				"development": {
+					"$ref": "#/definitions/environment",
+					"title": "The development targetting rules"
+				}
+			}
+		},
+		"tags": {
+			"title": "The tags associated to the feature flag",
+			"type": "array",
+			"additionalItems": false,
+			"minItems": 1,
+			"uniqueItems": true,
+			"items": {
+				"type": "string",
+				"pattern": "^[a-zA-Z0-9_\\-\\.]+$"
+			}
+		}
+	},
+	"definitions": {
+		"environment": {
+			"type": "object",
+			"additionalProperties": false,
+			"required": [
+				"defaultVariation"
+			],
+			"properties": {
+				"defaultVariation": {
+					"type": "string",
+					"title": "The variation to use when neither targets or rules match",
+					"minLength": 1,
+					"pattern": "^[a-zA-Z0-9_-]+$"
+				},
+				"targets": {
+					"type": "array",
+					"title": "The explicit farms to target",
+					"additionalItems": false,
+					"minItems": 1,
+					"items": {
+						"$ref": "#/definitions/target"
+					}
+				},
+				"rules": {
+					"type": "array",
+					"title": "The sequential rules which are evaluated when not matched by an explicit target",
+					"additionalItems": false,
+					"minItems": 1,
+					"items": {
+						"$ref": "#/definitions/rule"
+					}
+				},
+				"disabled": {
+					"type": "boolean",
+					"title": "If true, the defaultVariation is always used, and the targets and rules are ignored."
+				}
+			}
+		},
+		"rule": {
+			"type": "object",
+			"title": "A targetting rule",
+			"additionalProperties": false,
+			"required": [
+				"variation"
+			],
+			"minProperties": 2,
+			"properties": {
+				"dataCenters": {
+					"type": "array",
+					"title": "The set of d2l data centers to target",
+					"additionalItems": false,
+					"minItems": 1,
+					"uniqueItems": true,
+					"items": {
+						"type": "string",
+						"title": "Name of a d2l data center",
+						"enum": [
+							"ap01",
+							"ap02",
+							"ca05",
+							"ca1d",
+							"ca1p",
+							"ca3d",
+							"ca3p",
+							"eu01",
+							"us04"
+						]
+					}
+				},
+				"versions": {
+					"type": "object",
+					"title": "The bundle versions to target",
+					"additionalProperties": false,
+					"minProperties": 1,
+					"properties": {
+						"start": {
+							"$ref": "#/definitions/version",
+							"title": "The version to start targetting at (inclusive)",
+							"examples": [
+								"10.8.4.12256"
+							]
+						},
+						"end": {
+							"$ref": "#/definitions/version",
+							"title": "The version to stop targetting at (inclusive)",
+							"examples": [
+								"10.8.4.99999"
+							]
+						}
+					}
+				},
+				"variation": {
+					"type": "string",
+					"title": "The variation to target",
+					"minLength": 1,
+					"pattern": "^[a-zA-Z0-9_-]+$"
+				}
+			}
+		},
+		"target": {
+			"type": "object",
+			"additionalProperties": false,
+			"required": [
+				"variation"
+			],
+			"minProperties": 2,
+			"properties": {
+				"farms": {
+					"type": "array",
+					"title": "The set of farms to target",
+					"additionalItems": false,
+					"minItems": 1,
+					"uniqueItems": true,
+					"items": {
+						"anyOf": [
+							{
+								"$ref": "#/definitions/farmIdTarget"
+							},
+							{
+								"$ref": "#/definitions/farmTarget"
+							}
+						]
+					}
+				},
+				"variation": {
+					"type": "string",
+					"title": "The variation to target",
+					"minLength": 1,
+					"pattern": "^[a-zA-Z0-9_-]+$"
+				}
+			}
+		},
+		"farmIdTarget": {
+			"type": "string",
+			"title": "The farm id to target",
+			"pattern": "^[A-Za-z0-9_-]{2,40}$"
+		},
+		"farmTarget": {
+			"type": "object",
+			"additionalProperties": false,
+			"required": [
+				"farmId",
+				"comments"
+			],
+			"properties": {
+				"farmId": {
+					"$ref": "#/definitions/farmIdTarget"
+				},
+				"comments": {
+					"type": "string",
+					"title": "The comments about the farm",
+					"minLength": 1
+				}
+			}
+		},
+		"variation": {
+			"type": "object",
+			"additionalProperties": false,
+			"required": [
+				"key",
+				"value"
+			],
+			"properties": {
+				"key": {
+					"type": "string",
+					"title": "The variation key",
+					"minLength": 1,
+					"pattern": "^[a-zA-Z0-9_-]+$"
+				},
+				"name": {
+					"type": "string",
+					"title": "The human readable name of the variation",
+					"minLength": 1
+				},
+				"description": {
+					"type": "string",
+					"title": "The description of what the variation controls",
+					"minLength": 1
+				},
+				"value": {
+					"type": [
+						"string",
+						"integer",
+						"number"
+					],
+					"title": "The value of the variaent"
+				}
+			}
+		},
+		"version": {
+			"type": "string",
+			"pattern": "^[1-9][0-9]\\.[1-9]?[0-9]\\.[1-9]?[0-9](?:\\.[1-9]?[0-9]{0,4})?$"
+		}
+	}
+}

--- a/schemas/instance-boolean/v3_3.json
+++ b/schemas/instance-boolean/v3_3.json
@@ -1,0 +1,323 @@
+{
+	"$schema": "http://json-schema.org/draft-06/schema#",
+	"$id": "http://schemas.dev.brightspace.com/feature-flags/instance-boolean/v3_3.json",
+	"type": "object",
+	"additionalProperties": false,
+	"required": [
+		"$schema",
+		"name",
+		"environments"
+	],
+	"properties": {
+		"$schema": {
+			"type": "string",
+			"title": "The schema which uniquely identifies the feature flag type",
+			"enum": [
+				"http://schemas.dev.brightspace.com/feature-flags/instance-boolean/v3_3.json"
+			]
+		},
+		"name": {
+			"type": "string",
+			"title": "The feature flag name",
+			"minLength": 1
+		},
+		"description": {
+			"type": "string",
+			"title": "The description of what the feature flag controls",
+			"minLength": 1
+		},
+		"rallyId": {
+			"type": "string",
+			"title": "The rally identifier for the associated defect/feature.",
+			"pattern": "^(DE|F|US)\\d+"
+		},
+		"variations": {
+			"type": "object",
+			"title": "The keyed enumeration of variations. The keys are referenced elsewhere in the document.",
+			"additionalProperties": false,
+			"required": [
+				"true",
+				"false"
+			],
+			"properties": {
+				"true": {
+					"$ref": "#/definitions/variation",
+					"title": "The true variation key"
+				},
+				"false": {
+					"$ref": "#/definitions/variation",
+					"title": "The false variation key"
+				}
+			}
+		},
+		"environments": {
+			"type": "object",
+			"title": "The environment specific targetting rules",
+			"additionalProperties": false,
+			"required": [
+				"production",
+				"development"
+			],
+			"properties": {
+				"production": {
+					"$ref": "#/definitions/environment",
+					"title": "The production targetting rules"
+				},
+				"development": {
+					"$ref": "#/definitions/environment",
+					"title": "The development targetting rules"
+				}
+			}
+		},
+		"tags": {
+			"title": "The tags associated to the feature flag",
+			"type": "array",
+			"additionalItems": false,
+			"minItems": 1,
+			"uniqueItems": true,
+			"items": {
+				"type": "string",
+				"pattern": "^[a-zA-Z0-9_\\-\\.]+$"
+			}
+		}
+	},
+	"definitions": {
+		"environment": {
+			"type": "object",
+			"additionalProperties": false,
+			"required": [
+				"defaultVariation"
+			],
+			"properties": {
+				"defaultVariation": {
+					"type": "string",
+					"title": "The variation to use when neither targets or rules match",
+					"enum": [
+						"true",
+						"false"
+					]
+				},
+				"targets": {
+					"type": "array",
+					"title": "The explicit instances to target",
+					"additionalItems": false,
+					"minItems": 1,
+					"items": {
+						"$ref": "#/definitions/target"
+					}
+				},
+				"rules": {
+					"type": "array",
+					"title": "The sequential rules which are evaluated when not matched by an explicit target",
+					"additionalItems": false,
+					"minItems": 1,
+					"items": {
+						"$ref": "#/definitions/rule"
+					}
+				},
+				"disabled": {
+					"type": "boolean",
+					"title": "If true, the defaultVariation is always used, and the targets and rules are ignored."
+				}
+			}
+		},
+		"rule": {
+			"type": "object",
+			"title": "A targetting rule",
+			"additionalProperties": false,
+			"required": [
+				"variation"
+			],
+			"minProperties": 2,
+			"properties": {
+				"dataCenters": {
+					"type": "array",
+					"title": "The set of d2l data centers to target",
+					"additionalItems": false,
+					"minItems": 1,
+					"uniqueItems": true,
+					"items": {
+						"type": "string",
+						"title": "Name of a d2l data center",
+						"enum": [
+							"ap01",
+							"ap02",
+							"ca05",
+							"ca1d",
+							"ca1p",
+							"ca3d",
+							"ca3p",
+							"eu01",
+							"us04"
+						]
+					}
+				},
+				"instanceNames": {
+					"type": "array",
+					"title": "The set of instance names to target",
+					"additionalItems": false,
+					"minItems": 1,
+					"uniqueItems": true,
+					"items": {
+						"type": "string",
+						"title": "The instance names to target",
+						"minLength": 1
+					}
+				},
+				"instanceTypes": {
+					"type": "array",
+					"title": "The set of d2l instances types to target",
+					"additionalItems": false,
+					"minItems": 1,
+					"uniqueItems": true,
+					"items": {
+						"type": "string",
+						"enum": [
+							"prod",
+							"dev",
+							"test"
+						]
+					}
+				},
+				"versions": {
+					"type": "object",
+					"title": "The product versions to target",
+					"additionalProperties": false,
+					"minProperties": 1,
+					"properties": {
+						"start": {
+							"$ref": "#/definitions/version",
+							"title": "The version to start targetting at (inclusive)",
+							"examples": [
+								"10.8.4.12256"
+							]
+						},
+						"end": {
+							"$ref": "#/definitions/version",
+							"title": "The version to stop targetting at (inclusive)",
+							"examples": [
+								"10.8.4.99999"
+							]
+						}
+					}
+				},
+				"variation": {
+					"type": "string",
+					"title": "The variation to target",
+					"enum": [
+						"true",
+						"false"
+					]
+				}
+			},
+			"dependencies": {
+				"instanceNames": [
+					"versions"
+				]
+			}
+		},
+		"target": {
+			"type": "object",
+			"additionalProperties": false,
+			"required": [
+				"variation"
+			],
+			"minProperties": 2,
+			"properties": {
+				"instances": {
+					"type": "array",
+					"title": "The set of instances to target",
+					"additionalItems": false,
+					"minItems": 1,
+					"uniqueItems": true,
+					"items": {
+						"anyOf": [
+							{
+								"$ref": "#/definitions/instanceIdTarget"
+							},
+							{
+								"$ref": "#/definitions/instanceTarget"
+							}
+						]
+					}
+				},
+				"instanceNames": {
+					"type": "array",
+					"title": "The set of instance names to target",
+					"additionalItems": false,
+					"minItems": 1,
+					"uniqueItems": true,
+					"items": {
+						"type": "string",
+						"title": "The instance names to target",
+						"minLength": 1
+					}
+				},
+				"instanceIds": {
+					"type": "array",
+					"title": "The set of instance ids to target",
+					"additionalItems": false,
+					"minItems": 1,
+					"uniqueItems": true,
+					"items": {
+						"$ref": "#/definitions/instanceIdTarget"
+					}
+				},
+				"variation": {
+					"type": "string",
+					"title": "The variation to target",
+					"enum": [
+						"true",
+						"false"
+					]
+				}
+			}
+		},
+		"instanceIdTarget": {
+			"type": "string",
+			"title": "The instance id to target",
+			"pattern": "^[0-9a-f]{8}(-[0-9a-f]{4}){3}-[0-9a-f]{12}"
+		},
+		"instanceTarget": {
+			"type": "object",
+			"additionalProperties": false,
+			"required": [
+				"instanceId",
+				"comments"
+			],
+			"properties": {
+				"instanceId": {
+					"$ref": "#/definitions/instanceIdTarget"
+				},
+				"comments": {
+					"type": "string",
+					"title": "The comments about the instance",
+					"minLength": 1
+				}
+			}
+		},
+		"variation": {
+			"type": "object",
+			"additionalProperties": false,
+			"required": [
+				"name"
+			],
+			"properties": {
+				"name": {
+					"type": "string",
+					"title": "The human readable name of the variation",
+					"minLength": 1
+				},
+				"description": {
+					"type": "string",
+					"title": "The description of what the variation controls",
+					"minLength": 1
+				}
+			}
+		},
+		"version": {
+			"type": "string",
+			"pattern": "^[1-9][0-9]\\.[1-9]?[0-9]\\.[1-9]?[0-9](?:\\.[1-9]?[0-9]{0,4})?$"
+		}
+	}
+}

--- a/schemas/instance-multivariate/v3_3.json
+++ b/schemas/instance-multivariate/v3_3.json
@@ -1,0 +1,319 @@
+{
+	"$schema": "http://json-schema.org/draft-06/schema#",
+	"$id": "http://schemas.dev.brightspace.com/feature-flags/instance-multivariate/v3_3.json",
+	"type": "object",
+	"additionalProperties": false,
+	"required": [
+		"$schema",
+		"name",
+		"environments",
+		"variations"
+	],
+	"properties": {
+		"$schema": {
+			"type": "string",
+			"title": "The schema which uniquely identifies the feature flag type",
+			"enum": [
+				"http://schemas.dev.brightspace.com/feature-flags/instance-multivariate/v3_3.json"
+			]
+		},
+		"name": {
+			"type": "string",
+			"title": "The feature flag name",
+			"minLength": 1
+		},
+		"description": {
+			"type": "string",
+			"title": "The description of what the feature flag controls",
+			"minLength": 1
+		},
+		"rallyId": {
+			"type": "string",
+			"title": "The rally identifier for the associated defect/feature.",
+			"pattern": "^(DE|F|US)\\d+"
+		},
+		"variations": {
+			"type": "array",
+			"title": "The keyed enumeration of variations. The keys are referenced elsewhere in the document.",
+			"additionalItems": false,
+			"minItems": 2,
+			"items": {
+				"$ref": "#/definitions/variation"
+			}
+		},
+		"environments": {
+			"type": "object",
+			"title": "The environment specific targetting rules",
+			"additionalProperties": false,
+			"required": [
+				"production",
+				"development"
+			],
+			"properties": {
+				"production": {
+					"$ref": "#/definitions/environment",
+					"title": "The production targetting rules"
+				},
+				"development": {
+					"$ref": "#/definitions/environment",
+					"title": "The development targetting rules"
+				}
+			}
+		},
+		"tags": {
+			"title": "The tags associated to the feature flag",
+			"type": "array",
+			"additionalItems": false,
+			"minItems": 1,
+			"uniqueItems": true,
+			"items": {
+				"type": "string",
+				"pattern": "^[a-zA-Z0-9_\\-\\.]+$"
+			}
+		}
+	},
+	"definitions": {
+		"environment": {
+			"type": "object",
+			"additionalProperties": false,
+			"required": [
+				"defaultVariation"
+			],
+			"properties": {
+				"defaultVariation": {
+					"type": "string",
+					"title": "The variation to use when neither targets or rules match",
+					"minLength": 1,
+					"pattern": "^[a-zA-Z0-9_-]+$"
+				},
+				"targets": {
+					"type": "array",
+					"title": "The explicit instances to target",
+					"additionalItems": false,
+					"minItems": 1,
+					"items": {
+						"$ref": "#/definitions/target"
+					}
+				},
+				"rules": {
+					"type": "array",
+					"title": "The sequential rules which are evaluated when not matched by an explicit target",
+					"additionalItems": false,
+					"minItems": 1,
+					"items": {
+						"$ref": "#/definitions/rule"
+					}
+				}
+			}
+		},
+		"rule": {
+			"type": "object",
+			"title": "A targetting rule",
+			"additionalProperties": false,
+			"required": [
+				"variation"
+			],
+			"minProperties": 2,
+			"properties": {
+				"dataCenters": {
+					"type": "array",
+					"title": "The set of d2l data centers to target",
+					"additionalItems": false,
+					"minItems": 1,
+					"uniqueItems": true,
+					"items": {
+						"type": "string",
+						"title": "Name of a d2l data center",
+						"enum": [
+							"ap01",
+							"ap02",
+							"ca05",
+							"ca1d",
+							"ca1p",
+							"ca3d",
+							"ca3p",
+							"eu01",
+							"us04"
+						]
+					}
+				},
+				"instanceNames": {
+					"type": "array",
+					"title": "The set of instance names to target",
+					"additionalItems": false,
+					"minItems": 1,
+					"uniqueItems": true,
+					"items": {
+						"type": "string",
+						"title": "The instance names to target",
+						"minLength": 1
+					}
+				},
+				"instanceTypes": {
+					"type": "array",
+					"title": "The set of d2l instances types to target",
+					"additionalItems": false,
+					"minItems": 1,
+					"uniqueItems": true,
+					"items": {
+						"type": "string",
+						"enum": [
+							"prod",
+							"dev",
+							"test"
+						]
+					}
+				},
+				"versions": {
+					"type": "object",
+					"title": "The product versions to target",
+					"additionalProperties": false,
+					"minProperties": 1,
+					"properties": {
+						"start": {
+							"$ref": "#/definitions/version",
+							"title": "The version to start targetting at (inclusive)",
+							"examples": [
+								"10.8.4.12256"
+							]
+						},
+						"end": {
+							"$ref": "#/definitions/version",
+							"title": "The version to stop targetting at (inclusive)",
+							"examples": [
+								"10.8.4.99999"
+							]
+						}
+					}
+				},
+				"variation": {
+					"type": "string",
+					"title": "The variation to target",
+					"minLength": 1,
+					"pattern": "^[a-zA-Z0-9_-]+$"
+				}
+			},
+			"dependencies": {
+				"instanceNames": [
+					"versions"
+				]
+			}
+		},
+		"target": {
+			"type": "object",
+			"additionalProperties": false,
+			"required": [
+				"variation"
+			],
+			"minProperties": 2,
+			"properties": {
+				"instances": {
+					"type": "array",
+					"title": "The set of instances to target",
+					"additionalItems": false,
+					"minItems": 1,
+					"uniqueItems": true,
+					"items": {
+						"anyOf": [
+							{
+								"$ref": "#/definitions/instanceIdTarget"
+							},
+							{
+								"$ref": "#/definitions/instanceTarget"
+							}
+						]
+					}
+				},
+				"instanceNames": {
+					"type": "array",
+					"title": "The set of instance names to target",
+					"additionalItems": false,
+					"minItems": 1,
+					"uniqueItems": true,
+					"items": {
+						"type": "string",
+						"title": "The instance names to target",
+						"minLength": 1
+					}
+				},
+				"instanceIds": {
+					"type": "array",
+					"title": "The set of instance ids to target",
+					"additionalItems": false,
+					"minItems": 1,
+					"uniqueItems": true,
+					"items": {
+						"$ref": "#/definitions/instanceIdTarget"
+					}
+				},
+				"variation": {
+					"type": "string",
+					"title": "The variation to target",
+					"minLength": 1,
+					"pattern": "^[a-zA-Z0-9_-]+$"
+				}
+			}
+		},
+		"instanceIdTarget": {
+			"type": "string",
+			"title": "The instance id to target",
+			"pattern": "^[0-9a-f]{8}(-[0-9a-f]{4}){3}-[0-9a-f]{12}"
+		},
+		"instanceTarget": {
+			"type": "object",
+			"additionalProperties": false,
+			"required": [
+				"instanceId",
+				"comments"
+			],
+			"properties": {
+				"instanceId": {
+					"$ref": "#/definitions/instanceIdTarget"
+				},
+				"comments": {
+					"type": "string",
+					"title": "The comments about the instance",
+					"minLength": 1
+				}
+			}
+		},
+		"variation": {
+			"type": "object",
+			"additionalProperties": false,
+			"required": [
+				"key",
+				"value"
+			],
+			"properties": {
+				"key": {
+					"type": "string",
+					"title": "The variation key",
+					"minLength": 1,
+					"pattern": "^[a-zA-Z0-9_-]+$"
+				},
+				"name": {
+					"type": "string",
+					"title": "The human readable name of the variation",
+					"minLength": 1
+				},
+				"description": {
+					"type": "string",
+					"title": "The description of what the variation controls",
+					"minLength": 1
+				},
+				"value": {
+					"type": [
+						"string",
+						"integer",
+						"number"
+					],
+					"title": "The value of the variaent"
+				}
+			}
+		},
+		"version": {
+			"type": "string",
+			"pattern": "^[1-9][0-9]\\.[1-9]?[0-9]\\.[1-9]?[0-9](?:\\.[1-9]?[0-9]{0,4})?$"
+		}
+	}
+}

--- a/schemas/org-boolean/v3_3.json
+++ b/schemas/org-boolean/v3_3.json
@@ -1,0 +1,337 @@
+{
+	"$schema": "http://json-schema.org/draft-06/schema#",
+	"$id": "http://schemas.dev.brightspace.com/feature-flags/org-boolean/v3_3.json",
+	"type": "object",
+	"additionalProperties": false,
+	"required": [
+		"$schema",
+		"name",
+		"environments"
+	],
+	"properties": {
+		"$schema": {
+			"type": "string",
+			"title": "The schema which uniquely identifies the feature flag type",
+			"enum": [
+				"http://schemas.dev.brightspace.com/feature-flags/org-boolean/v3_3.json"
+			]
+		},
+		"name": {
+			"type": "string",
+			"title": "The feature flag name",
+			"minLength": 1
+		},
+		"description": {
+			"type": "string",
+			"title": "The description of what the feature flag controls",
+			"minLength": 1
+		},
+		"rallyId": {
+			"type": "string",
+			"title": "The rally identifier for the associated defect/feature.",
+			"pattern": "^(DE|F|US)\\d+"
+		},
+		"variations": {
+			"type": "object",
+			"title": "The keyed enumeration of variations. The keys are referenced elsewhere in the document.",
+			"additionalProperties": false,
+			"required": [
+				"true",
+				"false"
+			],
+			"properties": {
+				"true": {
+					"$ref": "#/definitions/variation",
+					"title": "The true variation key"
+				},
+				"false": {
+					"$ref": "#/definitions/variation",
+					"title": "The false variation key"
+				}
+			}
+		},
+		"environments": {
+			"type": "object",
+			"title": "The environment specific targetting rules",
+			"additionalProperties": false,
+			"required": [
+				"production",
+				"development"
+			],
+			"properties": {
+				"production": {
+					"$ref": "#/definitions/environment",
+					"title": "The production targetting rules"
+				},
+				"development": {
+					"$ref": "#/definitions/environment",
+					"title": "The development targetting rules"
+				}
+			}
+		},
+		"tags": {
+			"title": "The tags associated to the feature flag",
+			"type": "array",
+			"additionalItems": false,
+			"minItems": 1,
+			"uniqueItems": true,
+			"items": {
+				"type": "string",
+				"pattern": "^[a-zA-Z0-9_\\-\\.]+$"
+			}
+		}
+	},
+	"definitions": {
+		"environment": {
+			"type": "object",
+			"additionalProperties": false,
+			"required": [
+				"defaultVariation"
+			],
+			"properties": {
+				"defaultVariation": {
+					"type": "string",
+					"title": "The variation to use when neither targets or rules match",
+					"enum": [
+						"true",
+						"false"
+					]
+				},
+				"targets": {
+					"type": "array",
+					"title": "The explicit instances to target",
+					"additionalItems": false,
+					"minItems": 1,
+					"items": {
+						"$ref": "#/definitions/target"
+					}
+				},
+				"rules": {
+					"type": "array",
+					"title": "The sequential rules which are evaluated when not matched by an explicit target",
+					"additionalItems": false,
+					"minItems": 1,
+					"items": {
+						"$ref": "#/definitions/rule"
+					}
+				}
+			}
+		},
+		"rule": {
+			"type": "object",
+			"title": "A targetting rule",
+			"additionalProperties": false,
+			"required": [
+				"variation"
+			],
+			"minProperties": 2,
+			"properties": {
+				"awsRegions": {
+					"type": "array",
+					"title": "The aws region the tenant is configured to store their data in",
+					"additionalItems": false,
+					"minItems": 1,
+					"uniqueItems": true,
+					"items": {
+						"type": "string",
+						"title": "The aws region",
+						"enum": [
+							"ap-southeast-1",
+							"ap-southeast-2",
+							"ca-central-1",
+							"eu-west-1",
+							"us-east-1"
+						]
+					}
+				},
+				"dataCenters": {
+					"type": "array",
+					"title": "The set of d2l data centers to target",
+					"additionalItems": false,
+					"minItems": 1,
+					"uniqueItems": true,
+					"items": {
+						"type": "string",
+						"title": "Name of a d2l data center",
+						"enum": [
+							"ap01",
+							"ap02",
+							"ca05",
+							"ca1d",
+							"ca1p",
+							"ca3d",
+							"ca3p",
+							"eu01",
+							"us04"
+						]
+					}
+				},
+				"instanceTypes": {
+					"type": "array",
+					"title": "The set of d2l instances types to target",
+					"additionalItems": false,
+					"minItems": 1,
+					"uniqueItems": true,
+					"items": {
+						"type": "string",
+						"enum": [
+							"prod",
+							"dev",
+							"test"
+						]
+					}
+				},
+				"tenantDomains": {
+					"type": "array",
+					"title": "The set of tenant domains to target",
+					"additionalItems": false,
+					"minItems": 1,
+					"uniqueItems": true,
+					"items": {
+						"type": "string",
+						"title": "The tenant domains to target",
+						"minLength": 1
+					}
+				},
+				"versions": {
+					"type": "object",
+					"title": "The product versions to target",
+					"additionalProperties": false,
+					"minProperties": 1,
+					"properties": {
+						"start": {
+							"$ref": "#/definitions/version",
+							"title": "The version to start targetting at (inclusive)",
+							"examples": [
+								"10.8.4.12256"
+							]
+						},
+						"end": {
+							"$ref": "#/definitions/version",
+							"title": "The version to stop targetting at (inclusive)",
+							"examples": [
+								"10.8.4.99999"
+							]
+						}
+					}
+				},
+				"variation": {
+					"type": "string",
+					"title": "The variation to target",
+					"enum": [
+						"true",
+						"false"
+					]
+				}
+			},
+			"dependencies": {
+				"tenantDomains": [
+					"versions"
+				]
+			}
+		},
+		"target": {
+			"type": "object",
+			"additionalProperties": false,
+			"required": [
+				"variation"
+			],
+			"minProperties": 2,
+			"properties": {
+				"tenants": {
+					"type": "array",
+					"title": "The set of tenants to target",
+					"additionalItems": false,
+					"minItems": 1,
+					"uniqueItems": true,
+					"items": {
+						"anyOf": [
+							{
+								"$ref": "#/definitions/tenantIdTarget"
+							},
+							{
+								"$ref": "#/definitions/tenantTarget"
+							}
+						]
+					}
+				},
+				"tenantDomains": {
+					"type": "array",
+					"title": "The set of tenant domains to target",
+					"additionalItems": false,
+					"minItems": 1,
+					"uniqueItems": true,
+					"items": {
+						"type": "string",
+						"title": "The tenant domains to target",
+						"minLength": 1
+					}
+				},
+				"tenantIds": {
+					"type": "array",
+					"title": "The set of tenant ids to target",
+					"additionalItems": false,
+					"minItems": 1,
+					"uniqueItems": true,
+					"items": {
+						"$ref": "#/definitions/tenantIdTarget"
+					}
+				},
+				"variation": {
+					"type": "string",
+					"title": "The variation to target",
+					"enum": [
+						"true",
+						"false"
+					]
+				}
+			}
+		},
+		"tenantIdTarget": {
+			"type": "string",
+			"title": "The tenant id to target",
+			"pattern": "^[0-9a-f]{8}(-[0-9a-f]{4}){3}-[0-9a-f]{12}"
+		},
+		"tenantTarget": {
+			"type": "object",
+			"additionalProperties": false,
+			"required": [
+				"tenantId",
+				"comments"
+			],
+			"properties": {
+				"tenantId": {
+					"$ref": "#/definitions/tenantIdTarget"
+				},
+				"comments": {
+					"type": "string",
+					"title": "The comments about the tenant",
+					"minLength": 1
+				}
+			}
+		},
+		"variation": {
+			"type": "object",
+			"additionalProperties": false,
+			"required": [
+				"name"
+			],
+			"properties": {
+				"name": {
+					"type": "string",
+					"title": "The human readable name of the variation",
+					"minLength": 1
+				},
+				"description": {
+					"type": "string",
+					"title": "The description of what the variation controls",
+					"minLength": 1
+				}
+			}
+		},
+		"version": {
+			"type": "string",
+			"pattern": "^[1-9][0-9]\\.[1-9]?[0-9]\\.[1-9]?[0-9](?:\\.[1-9]?[0-9]{0,4})?$"
+		}
+	}
+}

--- a/schemas/org-multivariate/v3_3.json
+++ b/schemas/org-multivariate/v3_3.json
@@ -1,0 +1,337 @@
+{
+	"$schema": "http://json-schema.org/draft-06/schema#",
+	"$id": "http://schemas.dev.brightspace.com/feature-flags/org-multivariate/v3_3.json",
+	"type": "object",
+	"additionalProperties": false,
+	"required": [
+		"$schema",
+		"name",
+		"environments",
+		"variations"
+	],
+	"properties": {
+		"$schema": {
+			"type": "string",
+			"title": "The schema which uniquely identifies the feature flag type",
+			"enum": [
+				"http://schemas.dev.brightspace.com/feature-flags/org-multivariate/v3_3.json"
+			]
+		},
+		"name": {
+			"type": "string",
+			"title": "The feature flag name",
+			"minLength": 1
+		},
+		"description": {
+			"type": "string",
+			"title": "The description of what the feature flag controls",
+			"minLength": 1
+		},
+		"rallyId": {
+			"type": "string",
+			"title": "The rally identifier for the associated defect/feature.",
+			"pattern": "^(DE|F|US)\\d+"
+		},
+		"variations": {
+			"type": "array",
+			"title": "The keyed enumeration of variations. The keys are referenced elsewhere in the document.",
+			"additionalItems": false,
+			"minItems": 2,
+			"items": {
+				"$ref": "#/definitions/variation"
+			}
+		},
+		"environments": {
+			"type": "object",
+			"title": "The environment specific targetting rules",
+			"additionalProperties": false,
+			"required": [
+				"production",
+				"development"
+			],
+			"properties": {
+				"production": {
+					"$ref": "#/definitions/environment",
+					"title": "The production targetting rules"
+				},
+				"development": {
+					"$ref": "#/definitions/environment",
+					"title": "The development targetting rules"
+				}
+			}
+		},
+		"tags": {
+			"title": "The tags associated to the feature flag",
+			"type": "array",
+			"additionalItems": false,
+			"minItems": 1,
+			"uniqueItems": true,
+			"items": {
+				"type": "string",
+				"pattern": "^[a-zA-Z0-9_\\-\\.]+$"
+			}
+		}
+	},
+	"definitions": {
+		"environment": {
+			"type": "object",
+			"additionalProperties": false,
+			"required": [
+				"defaultVariation"
+			],
+			"properties": {
+				"defaultVariation": {
+					"type": "string",
+					"title": "The variation to use when neither targets or rules match",
+					"minLength": 1,
+					"pattern": "^[a-zA-Z0-9_-]+$"
+				},
+				"targets": {
+					"type": "array",
+					"title": "The explicit instances to target",
+					"additionalItems": false,
+					"minItems": 1,
+					"items": {
+						"$ref": "#/definitions/target"
+					}
+				},
+				"rules": {
+					"type": "array",
+					"title": "The sequential rules which are evaluated when not matched by an explicit target",
+					"additionalItems": false,
+					"minItems": 1,
+					"items": {
+						"$ref": "#/definitions/rule"
+					}
+				}
+			}
+		},
+		"rule": {
+			"type": "object",
+			"title": "A targetting rule",
+			"additionalProperties": false,
+			"required": [
+				"variation"
+			],
+			"minProperties": 2,
+			"properties": {
+				"awsRegions": {
+					"type": "array",
+					"title": "The aws region the tenant is configured to store their data in",
+					"additionalItems": false,
+					"minItems": 1,
+					"uniqueItems": true,
+					"items": {
+						"type": "string",
+						"title": "The aws region",
+						"enum": [
+							"ap-southeast-1",
+							"ap-southeast-2",
+							"ca-central-1",
+							"eu-west-1",
+							"us-east-1"
+						]
+					}
+				},
+				"dataCenters": {
+					"type": "array",
+					"title": "The set of d2l data centers to target",
+					"additionalItems": false,
+					"minItems": 1,
+					"uniqueItems": true,
+					"items": {
+						"type": "string",
+						"title": "Name of a d2l data center",
+						"enum": [
+							"ap01",
+							"ap02",
+							"ca05",
+							"ca1d",
+							"ca1p",
+							"ca3d",
+							"ca3p",
+							"eu01",
+							"us04"
+						]
+					}
+				},
+				"instanceTypes": {
+					"type": "array",
+					"title": "The set of d2l instances types to target",
+					"additionalItems": false,
+					"minItems": 1,
+					"uniqueItems": true,
+					"items": {
+						"type": "string",
+						"enum": [
+							"prod",
+							"dev",
+							"test"
+						]
+					}
+				},
+				"tenantDomains": {
+					"type": "array",
+					"title": "The set of tenant domains to target",
+					"additionalItems": false,
+					"minItems": 1,
+					"uniqueItems": true,
+					"items": {
+						"type": "string",
+						"title": "The tenant domains to target",
+						"minLength": 1
+					}
+				},
+				"versions": {
+					"type": "object",
+					"title": "The product versions to target",
+					"additionalProperties": false,
+					"minProperties": 1,
+					"properties": {
+						"start": {
+							"$ref": "#/definitions/version",
+							"title": "The version to start targetting at (inclusive)",
+							"examples": [
+								"10.8.4.12256"
+							]
+						},
+						"end": {
+							"$ref": "#/definitions/version",
+							"title": "The version to stop targetting at (inclusive)",
+							"examples": [
+								"10.8.4.99999"
+							]
+						}
+					}
+				},
+				"variation": {
+					"type": "string",
+					"title": "The variation to target",
+					"minLength": 1,
+					"pattern": "^[a-zA-Z0-9_-]+$"
+				}
+			},
+			"dependencies": {
+				"tenantDomains": [
+					"versions"
+				]
+			}
+		},
+		"target": {
+			"type": "object",
+			"additionalProperties": false,
+			"required": [
+				"variation"
+			],
+			"minProperties": 2,
+			"properties": {
+				"tenants": {
+					"type": "array",
+					"title": "The set of tenants to target",
+					"additionalItems": false,
+					"minItems": 1,
+					"uniqueItems": true,
+					"items": {
+						"anyOf": [
+							{
+								"$ref": "#/definitions/tenantIdTarget"
+							},
+							{
+								"$ref": "#/definitions/tenantTarget"
+							}
+						]
+					}
+				},
+				"tenantDomains": {
+					"type": "array",
+					"title": "The set of tenant domains to target",
+					"additionalItems": false,
+					"minItems": 1,
+					"uniqueItems": true,
+					"items": {
+						"type": "string",
+						"title": "The tenant domains to target",
+						"minLength": 1
+					}
+				},
+				"tenantIds": {
+					"type": "array",
+					"title": "The set of tenant ids to target",
+					"additionalItems": false,
+					"minItems": 1,
+					"uniqueItems": true,
+					"items": {
+						"$ref": "#/definitions/tenantIdTarget"
+					}
+				},
+				"variation": {
+					"type": "string",
+					"title": "The variation to target",
+					"minLength": 1,
+					"pattern": "^[a-zA-Z0-9_-]+$"
+				}
+			}
+		},
+		"tenantIdTarget": {
+			"type": "string",
+			"title": "The tenant id to target",
+			"pattern": "^[0-9a-f]{8}(-[0-9a-f]{4}){3}-[0-9a-f]{12}"
+		},
+		"tenantTarget": {
+			"type": "object",
+			"additionalProperties": false,
+			"required": [
+				"tenantId",
+				"comments"
+			],
+			"properties": {
+				"tenantId": {
+					"$ref": "#/definitions/tenantIdTarget"
+				},
+				"comments": {
+					"type": "string",
+					"title": "The comments about the tenant",
+					"minLength": 1
+				}
+			}
+		},
+		"variation": {
+			"type": "object",
+			"additionalProperties": false,
+			"required": [
+				"key",
+				"value"
+			],
+			"properties": {
+				"key": {
+					"type": "string",
+					"title": "The variation key",
+					"minLength": 1,
+					"pattern": "^[a-zA-Z0-9_-]+$"
+				},
+				"name": {
+					"type": "string",
+					"title": "The human readable name of the variation",
+					"minLength": 1
+				},
+				"description": {
+					"type": "string",
+					"title": "The description of what the variation controls",
+					"minLength": 1
+				},
+				"value": {
+					"type": [
+						"string",
+						"integer",
+						"number"
+					],
+					"title": "The value of the variaent"
+				}
+			}
+		},
+		"version": {
+			"type": "string",
+			"pattern": "^[1-9][0-9]\\.[1-9]?[0-9]\\.[1-9]?[0-9](?:\\.[1-9]?[0-9]{0,4})?$"
+		}
+	}
+}

--- a/src/sortableVersionBuilder.js
+++ b/src/sortableVersionBuilder.js
@@ -1,23 +1,19 @@
-function parseRevision( revision, start ) {
+function parseRevision( revision, defaultRevision ) {
 	if( revision !== undefined ) {
 		return parseInt( revision );
 	}
 
-	if( start ) {
-		return 0;
-	}
-
-	return 99999;
+	return defaultRevision;
 }
 
-module.exports = function( version, start ) {
+module.exports = function( version, defaultRevision ) {
 
 	const parts = version.match( /^([1-9][0-9])\.([1-9]?[0-9])\.([1-9]?[0-9])(?:\.([1-9]?[0-9]{0,4}))?$/ );
 
 	const major = parseInt( parts[ 1 ] );
 	const minor = parseInt( parts[ 2 ] );
 	const build = parseInt( parts[ 3 ] );
-	const revision = parseRevision( parts[4], start );
+	const revision = parseRevision( parts[4], defaultRevision );
 
 	return (
 		major * 1e9

--- a/src/sortableVersionBuilder.js
+++ b/src/sortableVersionBuilder.js
@@ -1,12 +1,23 @@
+function parseRevision( revision, start ) {
+	if( revision !== undefined ) {
+		return parseInt( revision );
+	}
 
-module.exports = function( version ) {
+	if( start ) {
+		return 0;
+	}
 
-	const parts = version.match( /^([1-9][0-9])\.([1-9]?[0-9])\.([1-9]?[0-9])\.([1-9]?[0-9]{0,4})$/ );
+	return 99999;
+}
+
+module.exports = function( version, start ) {
+
+	const parts = version.match( /^([1-9][0-9])\.([1-9]?[0-9])\.([1-9]?[0-9])(?:\.([1-9]?[0-9]{0,4}))?$/ );
 
 	const major = parseInt( parts[ 1 ] );
 	const minor = parseInt( parts[ 2 ] );
 	const build = parseInt( parts[ 3 ] );
-	const revision = parseInt( parts[ 4 ] );
+	const revision = parseRevision( parts[4], start );
 
 	return (
 		major * 1e9

--- a/src/sortableVersionRangeParser.js
+++ b/src/sortableVersionRangeParser.js
@@ -9,11 +9,11 @@ module.exports = function( versions ) {
 	const result = {};
 
 	if( versions.start ) {
-		result.start = sortableVersionBuilder( versions.start );
+		result.start = sortableVersionBuilder( versions.start, true );
 	}
 
 	if( versions.end ) {
-		result.end = sortableVersionBuilder( versions.end );
+		result.end = sortableVersionBuilder( versions.end, false );
 	}
 	
 	if( result.start && result.end ) {

--- a/src/sortableVersionRangeParser.js
+++ b/src/sortableVersionRangeParser.js
@@ -9,11 +9,11 @@ module.exports = function( versions ) {
 	const result = {};
 
 	if( versions.start ) {
-		result.start = sortableVersionBuilder( versions.start, true );
+		result.start = sortableVersionBuilder( versions.start, 0 );
 	}
 
 	if( versions.end ) {
-		result.end = sortableVersionBuilder( versions.end, false );
+		result.end = sortableVersionBuilder( versions.end, 99999 );
 	}
 	
 	if( result.start && result.end ) {

--- a/test/sortableVersionBuilderTests.js
+++ b/test/sortableVersionBuilderTests.js
@@ -2,45 +2,27 @@ const assert = require( 'chai' ).assert;
 const sortableVersionBuilder = require( '../src/sortableVersionBuilder.js' );
 
 describe( 'sortableVersionBuilder', function() {
+	it( 'should convert minimum', function() {
 
-	describe( 'range start', function() {
-		const rangeStart = true;
-		commonTests( rangeStart );
-
-		it( 'should treat missing revision as minimum', function() {
-			const value = sortableVersionBuilder( '10.8.8', rangeStart );
-			assert.equal( value,  10080800000 );
-		} );
+		const value = sortableVersionBuilder( '10.0.0.0' );
+		assert.equal( value, 10000000000 );
 	} );
 
-	describe( 'range end', function() {
-		const rangeEnd = false;
+	it( 'should convert single digits', function() {
 
-		commonTests( rangeEnd );
-
-		it( 'should treat missing revision as maximum', function() {
-			const value = sortableVersionBuilder( '10.8.8', rangeEnd );
-			assert.equal( value,  10080899999 );
-		} );
+		const value = sortableVersionBuilder( '10.1.2.3' );
+		assert.equal( value, 10010200003 );
 	} );
 
-	function commonTests(start) {
-		it( 'should convert minimum', function() {
+	it( 'should convert full digits', function() {
 
-			const value = sortableVersionBuilder( '10.0.0.0', start );
-			assert.equal( value, 10000000000 );
-		} );
+		const value = sortableVersionBuilder( '99.88.77.66666' );
+		assert.equal( value, 99887766666 );
+	} );
 
-		it( 'should convert single digits', function() {
+	it( 'should use default revision when not specified', function() {
 
-			const value = sortableVersionBuilder( '10.1.2.3', start );
-			assert.equal( value, 10010200003 );
-		} );
-
-		it( 'should convert full digits', function() {
-
-			const value = sortableVersionBuilder( '99.88.77.66666', start );
-			assert.equal( value, 99887766666 );
-		} );
-	}
+		const value = sortableVersionBuilder( '99.88.77', 54321 );
+		assert.equal( value, 99887754321 );
+	} );
 } );

--- a/test/sortableVersionBuilderTests.js
+++ b/test/sortableVersionBuilderTests.js
@@ -3,21 +3,44 @@ const sortableVersionBuilder = require( '../src/sortableVersionBuilder.js' );
 
 describe( 'sortableVersionBuilder', function() {
 
-	it( 'should convert minimum', function() {
+	describe( 'range start', function() {
+		const rangeStart = true;
+		commonTests( rangeStart );
 
-		const value = sortableVersionBuilder( '10.0.0.0' );
-		assert.equal( value, 10000000000 );
+		it( 'should treat missing revision as minimum', function() {
+			const value = sortableVersionBuilder( '10.8.8', rangeStart );
+			assert.equal( value,  10080800000 );
+		} );
 	} );
 
-	it( 'should convert single digits', function() {
+	describe( 'range end', function() {
+		const rangeEnd = false;
 
-		const value = sortableVersionBuilder( '10.1.2.3' );
-		assert.equal( value, 10010200003 );
+		commonTests( rangeEnd );
+
+		it( 'should treat missing revision as maximum', function() {
+			const value = sortableVersionBuilder( '10.8.8', rangeEnd );
+			assert.equal( value,  10080899999 );
+		} );
 	} );
 
-	it( 'should convert full digits', function() {
+	function commonTests(start) {
+		it( 'should convert minimum', function() {
 
-		const value = sortableVersionBuilder( '99.88.77.66666' );
-		assert.equal( value, 99887766666 );
-	} );
+			const value = sortableVersionBuilder( '10.0.0.0', start );
+			assert.equal( value, 10000000000 );
+		} );
+
+		it( 'should convert single digits', function() {
+
+			const value = sortableVersionBuilder( '10.1.2.3', start );
+			assert.equal( value, 10010200003 );
+		} );
+
+		it( 'should convert full digits', function() {
+
+			const value = sortableVersionBuilder( '99.88.77.66666', start );
+			assert.equal( value, 99887766666 );
+		} );
+	}
 } );


### PR DESCRIPTION
these do the "right thing" depending on if its for the start or end of the version range

Noticed some mistakes in using version ranges. Where the goal was `serve false for versions <= 10.8.7`, the following was used:

```json
"rules": [{
  "variation": false,
  "versions": {
    "end": "10.8.7.0"
  }
}]
```

Where as the correct usage would've been

```json
"rules": [{
  "variation": false,
  "versions": {
    "end": "10.8.7.99999"
  }
}]
```

This change allows a user to not specify the revision if it's not specifically desired, and the builder will fill in the correct thing:

```js
"rules": [{
  "variation": false,
  "versions": {
    "start": "10.8.6", // equivalent to 10.8.6.0
    "end": "10.8.7" // equivalent to 10.8.7.99999
  }
}]
```